### PR TITLE
fix bug in p4annotate not properly formatting

### DIFF
--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -682,7 +682,7 @@ function! vp4#PerforceAnnotate(...) range
 
     " Clean up buffer, set local options, move cursor to saved position
     set modifiable
-    %right
+    %right 80
     setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap
     setlocal nonumber norelativenumber
     call s:PerforceAnnotateHighlight()


### PR DESCRIPTION
the %right option is padding for whatever width the buffer is before it gets vertically resized to 80