### PR TITLE
Use full path for annotation

### DIFF
--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -652,7 +652,7 @@ endfunction
     " which it was last edited.  Accepts a range to limit the section being
     " fully annotated.
 function! vp4#PerforceAnnotate(...) range
-    let filename = expand('%')
+    let filename = expand('%:p')
     if !s:PerforceAssertExists(filename) | return | endif
 
     " `p4 annotate` can only operate on revisions that exist in the depot.  If a


### PR DESCRIPTION
When doing `Vp4Annotate`, if you aren't at the depot root, you can't open the file. My company has a mono repo with many modules, so I typically cd and then vim into the specific directory. This fixed the issue for me. 