### PR TITLE
Support mono repo

### DIFF
--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -161,7 +161,7 @@ function! s:PerforceFstat(field, filename)
 
     " Extract the value from the string which looks like:
     "   ... headRev 65\n\n
-    let val = split(split(s, '\n')[0], ' ')[2]
+    let val = split(split(substitute(s, '\r', '', ''), '\n')[0])[2]
     if g:perforce_debug
         echom 'fstat got value ' . val . ' for field ' . a:field
                 \ . ' on file ' . a:filename

--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -112,6 +112,30 @@ function! s:PerforceWrite(cmd)
     endif
     execute command
 endfunction
+
+" Function to get the path of the file
+function! s:ExpandPath(file)
+    if exists("g:base_path_replacements")
+        echom "We have a base path replacements"
+        let l:oldPath = expand('%:p')
+        let l:replacements = items(g:base_path_replacements)
+        for item in l:replacements
+            echom "does " . l:oldPath . " match " . item[0]
+            if l:oldPath =~ item[0]
+                " We have a match
+                echom "Matched string " . item[0] . " in " . l:oldPath
+                let l:newFile = substitute(l:oldPath, item[0], item[1], "")
+                echom "New path " . l:newFile
+                return l:newFile
+            endif
+        endfor
+        echom "Did not find replacement, return"
+        return expand(a:file)
+    else
+        echom "Using default pathing"
+        return expand(a:file)
+    endif
+endfunction
 " }}}
 
 " {{{ Perforce checker infrastructure

--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -115,10 +115,12 @@ endfunction
 
 " Function to get the path of the file
 function! s:ExpandPath(file)
-    if exists("g:base_path_replacements")
-        echom "We have a base path replacements"
+    if exists("g:vp4_base_path_replacements")
+        if g:perforce_debug	
+            echom "We have a base path replacements"
+        endif
         let l:oldPath = expand('%:p')
-        let l:replacements = items(g:base_path_replacements)
+        let l:replacements = items(g:vp4_base_path_replacements)
         for item in l:replacements
             echom "does " . l:oldPath . " match " . item[0]
             if l:oldPath =~ item[0]

--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -341,14 +341,14 @@ endfunction
 " {{{ File editing
 " Call p4 add.
 function! vp4#PerforceAdd()
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
 
     call s:PerforceSystem('add ' .filename)
 endfunction
 
 " Call p4 delete.
 function! vp4#PerforceDelete(bang)
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertExists(filename) | return | endif
 
     if !a:bang
@@ -365,7 +365,7 @@ endfunction
 
 " Call p4 edit.
 function! vp4#PerforceEdit()
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertExists(filename) | return | endif
 
     call s:PerforceSystem('edit ' .filename)
@@ -376,7 +376,7 @@ endfunction
 
 " Call p4 revert.  Confirms before performing the revert.
 function! vp4#PerforceRevert(bang)
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertOpened(filename) | return | endif
 
     if !a:bang
@@ -397,7 +397,7 @@ endfunction
 " {{{ Change specification
 " Call p4 shelve
 function! vp4#PerforceShelve(bang)
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertOpened(filename) | return | endif
 
     let perforce_command = 'shelve'
@@ -438,7 +438,7 @@ endfunction
     " Uses the -o/-i options to avoid the confirmation on abort.
     " Works by opening a new window to write your change description.
 function! vp4#PerforceChange()
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     let perforce_command = 'change -o'
     let lnr = 25
 
@@ -478,7 +478,7 @@ endfunction
 " output in a preview window.
 function! vp4#PerforceDescribe()
 
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     let current_changelist = s:PerforceGetCurrentChangelist(filename)
 
     if !current_changelist
@@ -503,7 +503,7 @@ endfunction
 " Prompt the user to move file currently being edited to a different changelist.
     " Present the user with a list of current changes.
 function! vp4#PerforceReopen()
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertOpened(filename) | return | endif
 
     " Get the pending changes in the current client
@@ -540,7 +540,7 @@ endfunction
     "  #rev    diffs with given revision
     "  <none>  diffs with have revision
 function! vp4#PerforceDiff(...)
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
 
     " Check for options
     "   'a:0' is set to the number of extra arguments
@@ -676,7 +676,7 @@ endfunction
     " which it was last edited.  Accepts a range to limit the section being
     " fully annotated.
 function! vp4#PerforceAnnotate(...) range
-    let filename = expand('%:p')
+    let filename = s:ExpandPath('%:p')
     if !s:PerforceAssertExists(filename) | return | endif
 
     " `p4 annotate` can only operate on revisions that exist in the depot.  If a
@@ -738,7 +738,7 @@ function! vp4#PerforceFilelog(...)
         let max_history = a:1
     endif
 
-    let filename = s:PerforceStripRevision(expand('%'))
+    let filename = s:PerforceStripRevision(s:ExpandPath('%'))
     if !s:PerforceAssertExists(filename) | return | endif
 
     " Remember some stuff about this file
@@ -793,7 +793,7 @@ endfunction
 " Check if file exists in the depot and is not already opened for edit.  If so,
 " prompt user to open for edit.
 function! vp4#PromptForOpen()
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if &readonly && s:PerforceAssertExists(filename)
         let do_edit = input(filename .
                 \' is not opened for edit.  p4 edit it now? [y/n]: ')
@@ -815,7 +815,7 @@ function! s:PerforceOpenRevision()
         setlocal buftype=nofile
     endif
 
-    let filename = expand('%')
+    let filename = s:ExpandPath('%')
     if !s:PerforceAssertExists(filename) | return | endif
 
     " Print the file to this buffer

--- a/doc/vp4.txt
+++ b/doc/vp4.txt
@@ -229,6 +229,10 @@ OPTIONS                                                          *vp4-options*
 g:vp4_sync_options          Options to pass to perforce sync command when 
                             syncing files via the Explorer.
 
+g:vp4_base_path_replacements
+                            Allows P4 paths to be replaced at command time
+                            = { /home/u/bad/repo/ : /home/u/good/repo} (ex)
+                            = {} (default)
 ==============================================================================
 KNOWN ISSUES                                                      *vp4-issues*
 

--- a/plugin/vp4.vim
+++ b/plugin/vp4.vim
@@ -39,6 +39,7 @@ call s:set('g:_vp4_curpos', [0, 0, 0, 0])
 call s:set('g:_vp4_filetype', 'txt')
 call s:set('g:vp4_allow_open_depot_file', 1)
 call s:set('g:vp4_sync_options', '')
+call s:set('g:vp4_base_path_replacements', {})
 
 " }}}
 


### PR DESCRIPTION
Hiya!

I have a bit of a strange use case but wanted to see if these changes make sense for anyone else. My company uses a mono-repo for p4, and I'm using wsl to do my development (which also means I'm using `p4.exe` to run p4 commands, anyway). These lead to the following conditions to be met to use the Vp4 commands

1. I have to use the full path to a file for any p4 command
2. I have the perforce command synced to `t:/depot/....` instead of `/mnt/t/...` (this comes from the fact that I use the windows perforce executable, in wsl). 

This lead to me have to two major changes throughout the code

1. use the full path for most operations `expand('%:p')`
2. allow path replacements

That's what this PR does. My vimrc would have these additional parameters

```
let g:base_path_replacements = { '/mnt/t/': 't:/' }
let g:vp4_perforce_executable = 'p4.exe'
let g:chomp_carriage_return = 1
```

I have this in WIP incase anyone has feedback about what to add. Otherwise I'll pull out the echo statements and update the rest of the methods that might need to use this method.