### PR TITLE
Wrap debug messages in ExpandPath so that they don't trigger on save

### DIFF
--- a/autoload/vp4.vim
+++ b/autoload/vp4.vim
@@ -122,19 +122,29 @@ function! s:ExpandPath(file)
         let l:oldPath = expand('%:p')
         let l:replacements = items(g:vp4_base_path_replacements)
         for item in l:replacements
-            echom "does " . l:oldPath . " match " . item[0]
+            if g:perforce_debug
+                echom "does " . l:oldPath . " match " . item[0]
+            endif
             if l:oldPath =~ item[0]
                 " We have a match
-                echom "Matched string " . item[0] . " in " . l:oldPath
+                if g:perforce_debug
+                    echom "Matched string " . item[0] . " in " . l:oldPath
+                endif
                 let l:newFile = substitute(l:oldPath, item[0], item[1], "")
-                echom "New path " . l:newFile
+                if g:perforce_debug
+                    echom "New path " . l:newFile
+                endif
                 return l:newFile
             endif
         endfor
-        echom "Did not find replacement, return"
+        if g:perforce_debug
+            echom "Did not find replacement, return"
+        endif
         return expand(a:file)
     else
-        echom "Using default pathing"
+        if g:perforce_debug
+            echom "Using default pathing"
+        endif
         return expand(a:file)
     endif
 endfunction


### PR DESCRIPTION
Hi!

I grabbed the latest version of `vim-vp4` this morning and I started getting debug messages when saving. Since I have a single line `cmdheight` it means I have to press enter on `:w` (which is not so nice).

![vim-vp4](https://user-images.githubusercontent.com/5418661/103698995-ea5e1100-4faa-11eb-8f71-c141e0f1d4c6.png)

I fixed it locally by wrapping the `echom` calls that were added in`ExpandPath` in the last commit. I assume they are debug messages or something? This PR has them wrapped in `perforce_debug` checks.

I might have wrapped them too aggressively though, so feel free to tell me if I should nuke some of those additional checks I added.

Cheers!